### PR TITLE
Added timeout option for shell command

### DIFF
--- a/index.js
+++ b/index.js
@@ -315,7 +315,7 @@ instance.prototype.init_actions = function(system) {
 					type: 'number',
 					label: 'Timeout (ms) (Set to 0 for no timeout)',
 					id: 'timeout',
-					default: 5,
+					default: 5000,
 					min: 0,
 					max: 10000,
 					required: true
@@ -658,7 +658,7 @@ instance.prototype.action = function(action, extras) {
 	else if (id == 'exec') {
 		debug("Running path: '"+opt.path+"'");
 		exec(opt.path, {
-			timeout: opt.timeout === undefined ? 5 : opt.timeout
+			timeout: opt.timeout === undefined ? 5000 : opt.timeout
 		}, function(error, stdout, stderr) {
 
 				if (error) {

--- a/index.js
+++ b/index.js
@@ -658,7 +658,7 @@ instance.prototype.action = function(action, extras) {
 	else if (id == 'exec') {
 		debug("Running path: '"+opt.path+"'");
 		exec(opt.path, {
-			timeout: opt.timeout == null ? 5 : opt.timeout
+			timeout: opt.timeout === undefined ? 5 : opt.timeout
 		}, function(error, stdout, stderr) {
 
 				if (error) {

--- a/index.js
+++ b/index.js
@@ -313,11 +313,11 @@ instance.prototype.init_actions = function(system) {
 				},
 				{
 					type: 'number',
-					label: 'Timeout (ms) (Set to 0 for no timeout)',
+					label: 'Timeout (ms, between 500 and 20000)',
 					id: 'timeout',
 					default: 5000,
-					min: 0,
-					max: 10000,
+					min: 500,
+					max: 20000,
 					required: true
 				}
 			]
@@ -658,7 +658,7 @@ instance.prototype.action = function(action, extras) {
 	else if (id == 'exec') {
 		debug("Running path: '"+opt.path+"'");
 		exec(opt.path, {
-			timeout: opt.timeout === undefined ? 5000 : opt.timeout
+			timeout: opt.timeout
 		}, function(error, stdout, stderr) {
 
 				if (error) {

--- a/index.js
+++ b/index.js
@@ -313,7 +313,7 @@ instance.prototype.init_actions = function(system) {
 				},
 				{
 					type: 'number',
-					label: 'Timeout (Milliseconds)',
+					label: 'Timeout (ms) (Set to 0 for no timeout)',
 					id: 'timeout',
 					default: 5,
 					min: 0,

--- a/index.js
+++ b/index.js
@@ -658,7 +658,7 @@ instance.prototype.action = function(action, extras) {
 	else if (id == 'exec') {
 		debug("Running path: '"+opt.path+"'");
 		exec(opt.path, {
-			timeout: opt.timeout
+			timeout: opt.timeout === undefined ? 5000 : opt.timeout
 		}, function(error, stdout, stderr) {
 
 				if (error) {

--- a/index.js
+++ b/index.js
@@ -310,6 +310,15 @@ instance.prototype.init_actions = function(system) {
 					type: 'textinput',
 					label: 'Path',
 					id: 'path',
+				},
+				{
+					type: 'number',
+					label: 'Timeout (Milliseconds)',
+					id: 'timeout',
+					default: 5,
+					min: 0,
+					max: 10000,
+					required: true
 				}
 			]
 		},
@@ -649,7 +658,7 @@ instance.prototype.action = function(action, extras) {
 	else if (id == 'exec') {
 		debug("Running path: '"+opt.path+"'");
 		exec(opt.path, {
-			timeout: 5
+			timeout: opt.timeout == null ? 5 : opt.timeout
 		}, function(error, stdout, stderr) {
 
 				if (error) {


### PR DESCRIPTION
This awesome PR fixes #10, by adding a "Timeout" option to the Shell Command action. It leaves 5 ms as the default, however, so it won't mess up anybody else.

The why: if you're running a command on a slow computer, it could easily take longer than 5 milliseconds. As described in issue #10, I'm having issues running an AppleScript with `osascript` on a slower computer.