### PR TITLE
Page and history function

### DIFF
--- a/index.js
+++ b/index.js
@@ -627,7 +627,7 @@ instance.prototype.action = function(action, extras) {
 
 	if (self.BUTTON_ACTIONS.includes(id)) {
 		if (0 == opt.bank) {    // 'this' button
-			thePage = extras.page;
+//			thePage = extras.page;
 			theBank = extras.bank;
 		}
 		if (0 == opt.page) {	// 'this' page

--- a/index.js
+++ b/index.js
@@ -804,6 +804,7 @@ instance.prototype.changeControllerPage = function(surface, page, from) {
 		const pageIndex = self.pageHistory[surface].index + pageDirection;
 		const pageTarget = self.pageHistory[surface].history[pageIndex];
 
+		// change only if pageIndex points to a real page
 		if (pageTarget !== undefined) {
 			setImmediate(function () {
 				self.system.emit('device_page_set', surface, pageTarget);
@@ -817,13 +818,6 @@ instance.prototype.changeControllerPage = function(surface, page, from) {
 			self.system.emit('device_page_set', surface, page);
 		});
 
-		// Create page history object on first page change for a surface
-		// if (!self.pageHistory[surface]) {
-		// 	self.pageHistory[surface] = {
-		// 		history: [page],
-		// 		index: 0
-		// 	};
-		// } else {
 		// Clear forward page history beyond current index, add new history entry, increment index;
 		self.pageHistory[surface].history = self.pageHistory[surface].history.slice(0, self.pageHistory[surface].index + 1);
 		self.pageHistory[surface].history.push(page);
@@ -836,16 +830,7 @@ instance.prototype.changeControllerPage = function(surface, page, from) {
 			const endIndex = self.pageHistory[surface].history.length;
 			self.pageHistory[surface].history = self.pageHistory[surface].history.slice(startIndex, endIndex);
 		}
-		//}
 	}
-
-	/* 2-Jan-2020: fixed/obsolete. device.js now detects if a page change occurs
-		between a button press and release and 'releases' the correct page-bank
-	// If we change page while pushing a button, we need to tell the button that we were done with it
-	// TODO: Somehow handle the futile "action_release" of the same button on the new page
-	if (surface == extras.deviceid) {
-		self.system.emit('bank_pressed', extras.page, extras.bank, false, surface);
-	} */
 
 	return;
 };
@@ -996,12 +981,6 @@ instance.prototype.feedback = function(feedback, bank) {
 
 	}
 };
-
-
-
-
-
-
 
 
 instance_skel.extendedBy(instance);

--- a/index.js
+++ b/index.js
@@ -88,6 +88,10 @@ instance.prototype.init = function() {
 		'button_pressrelease', 'button_press','button_release','button_text','textcolor','bgcolor','panic_bank'
 	];
 
+	self.PAGE_ACTIONS = [
+		'set_page', 'set_page_byindex', 'inc_page', 'dec_page'
+	];
+	
 	self.pages_getall();
 	self.addSystemCallback('page_update', self.pages_update.bind(self));
 
@@ -626,6 +630,12 @@ instance.prototype.action = function(action, extras) {
 			thePage = extras.page;
 			theBank = extras.bank;
 		}
+		if (0 == opt.page) {	// 'this' page
+			thePage = extras.page;
+		}
+	}
+
+	if (self.PAGE_ACTIONS.includes(id)) {
 		if (0 == opt.page) {	// 'this' page
 			thePage = extras.page;
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bitfocus-companion",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"api_version": "1.0.0",
 	"description": "Internal functions",
 	"keywords": [ ],


### PR DESCRIPTION
- 'This' page is now supported for 'Set page' actions. Ex: "Set a different surface to 'this' page"
- Page history list adjusted so 'Back'/'Forward' now change pages in a more predictable way.
- 'This' button now supports different pages. Ex: "Change 'This' button (4) on Page 10". This allows an easier method to link buttons in the same place on different pages.