### PR TITLE
feat(variable): add 'Set custom variable to expression' action

### DIFF
--- a/index.js
+++ b/index.js
@@ -772,6 +772,27 @@ instance.prototype.init_actions = function (system) {
 				},
 			],
 		},
+		custom_variable_set_expression: {
+			label: 'Set custom variable expression',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Custom variable',
+					id: 'name',
+					default: Object.keys(self.custom_variables)[0],
+					choices: Object.entries(self.custom_variables).map(([id, info]) => ({
+						id: id,
+						label: id,
+					})),
+				},
+				{
+					type: 'textwithvariables',
+					label: 'Expression',
+					id: 'expression',
+					default: '',
+				},
+			],
+		},
 		custom_variable_store_variable: {
 			label: 'Store variable value to custom variable',
 			options: [
@@ -845,6 +866,8 @@ instance.prototype.action = function (action, extras) {
 
 	if (id == 'custom_variable_set_value') {
 		self.system.emit('custom_variable_set_value', opt.name, opt.value)
+	} else if (id === 'custom_variable_set_expression') {
+		self.system.emit('custom_variable_set_expression', opt.name, opt.expression)
 	} else if (id == 'custom_variable_store_variable') {
 		let value = ''
 		const id = opt.variable.split(':')


### PR DESCRIPTION
Add a 'Set custom variable to expression' action, with provides the ability to set a variable to an arithmetic expression, such as:

```
$(internal:custom_counter) + 1
```

Valid operators include:
- Binary operators:
  - Addition: `a + b`
  - Subtraction: `a - b`
  - Multiplication: `a * b`
  - Division: `a / b`
  - Modulous: `a % b`
  - Exponentiation: `a ^ b`
- Unary operators:
  - Unary Negataion: `-a`
- Expression grouping:
  - Parenthesis: `(a + b) * c`

Uses feature added by bitfocus/companion#1770.

Sample Action
![image](https://user-images.githubusercontent.com/5514878/139364231-19ac3e96-0ad4-4f2e-b3c1-0118cd720697.png)


Resolves #1723
Signed-off-by: Johnny Estilles <johnny@estilles.com>