### PR TITLE
Fix and add date variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,9 +40,12 @@ function instance(system, id, config) {
 		const hhmm = hh + ':' + mm
 		const hhmmss = hhmm + ':' + ss
 		self.setVariables({
+			date_iso: now.toISOString().slice(0,10),
 			date_y: now.getFullYear(),
 			date_m: month,
 			date_d: day,
+			date_dow: now.getDay(),
+			date_weekday: now.toLocaleString(undefined, {weekday: 'long'}),
 			time_hms: hhmmss,
 			time_hm: hhmm,
 			time_h: hh,
@@ -119,6 +122,12 @@ instance.prototype.init = function () {
 		instance_errors: 0,
 		instance_warns: 0,
 		instance_oks: 0,
+		date_iso: '',
+		date_y: '',
+		date_m: '',
+		date_d: '',
+		date_dow: '',
+		date_weekday: '',
 		time_hms: '',
 		time_hm: '',
 		time_h: '',
@@ -1487,6 +1496,30 @@ instance.prototype.update_variables = function () {
 		})
 	}
 
+	variables.push({
+		label: 'Date ISO (YYYY-MM-DD)',
+		name: 'date_iso',
+	})
+	variables.push({
+		label: 'Year (YYYY)',
+		name: 'date_y',
+	})
+	variables.push({
+		label: 'Month (MM)',
+		name: 'date_m',
+	})
+	variables.push({
+		label: 'Day (DD)',
+		name: 'date_d',
+	})
+	variables.push({
+		label: 'Day of week (number)',
+		name: 'date_dow',
+	})
+	variables.push({
+		label: 'Day of week (name)',
+		name: 'date_weekday',
+	})
 	variables.push({
 		label: 'Time of day (HH:MM:SS)',
 		name: 'time_hms',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bitfocus-companion",
-	"version": "1.8.1",
+	"version": "1.8.2",
 	"api_version": "1.0.0",
 	"description": "Internal functions",
 	"keywords": [],


### PR DESCRIPTION
Fixes https://github.com/bitfocus/companion-module-bitfocus-companion/pull/17 as the YMD variables were only partially set up. Also adds ISO date (YYYY-MM-DD) as a single variable and day of week (as number and name) which addresses https://github.com/bitfocus/companion-module-bitfocus-companion/issues/59.